### PR TITLE
feat: implement horizontal layour for mobile project cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,9 +2992,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3843,9 +3843,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/ProjectCard/ProjectCard.module.scss
+++ b/src/components/ProjectCard/ProjectCard.module.scss
@@ -135,7 +135,7 @@
   //For Mobile version
   @media (max-width: 639px){
     font-size: 0.65rem;
-    padding: 0.2 rem 0.4 rem;
+    padding: 0.2rem 0.4rem;
   }
 }
 

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -22,15 +22,6 @@ export function ProjectCard({
 }: ProjectCardProps) {
   return (
     <div className={styles.card}>
-      <div className={styles.content}>
-        <div className={styles.header}>
-          <div className={styles.titleSection}>
-            <h2 className={styles.title}>{title}</h2>
-            <p className={styles.author}>{author}</p>
-          </div>
-        </div>
-      </div>
-
       <div className={styles.preview}>
         {previewImageUrl ? (
           <img src={"/placeholder.svg"} alt={`${title} preview`} />
@@ -45,40 +36,50 @@ export function ProjectCard({
         )}
       </div>
 
-      <p className={styles.description}>{description}</p>
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <div className={styles.titleSection}>
+            <h2 className={styles.title}>{title}</h2>
+            <p className={styles.author}>{author}</p>
+          </div>
+        </div>
 
-      <div className={styles.tags}>
-        {tags.slice(0, 3).map((tag) => (
-          <span className={styles.tag} key={tag}>
-            {tag}
-          </span>
-        ))}
-        {tags.length > 3 && (
-          <span className={styles.tag}>+{tags.length - 3}</span>
-        )}
-      </div>
 
-      <div className={styles.links}>
-        <a
-          href={githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.codeButton}
-        >
-          <Github className={styles.icon} />
-          Code
-        </a>
-        {liveUrl && (
+        <p className={styles.description}>{description}</p>
+
+        <div className={styles.tags}>
+          {tags.slice(0, 3).map((tag) => (
+            <span className={styles.tag} key={tag}>
+              {tag}
+            </span>
+          ))}
+          {tags.length > 3 && (
+            <span className={styles.tag}>+{tags.length - 3}</span>
+          )}
+        </div>
+
+        <div className={styles.links}>
           <a
-            href={liveUrl}
+            href={githubUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className={styles.demoButton}
+            className={styles.codeButton}
           >
-            <ExternalLink className={styles.icon} />
-            Demo
+            <Github className={styles.icon} />
+            Code
           </a>
-        )}
+          {liveUrl && (
+            <a
+              href={liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.demoButton}
+            >
+              <ExternalLink className={styles.icon} />
+              Demo
+            </a>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Implements horizontal layout for project cards on mobile devices. 

### Changes made
- Added CSS media queries for screens < 640px
- Adjusted spacing for mobile optimization
- Maintained vertical layout for desktop/tablet screens

### Testing
- Tested on mobile Chrome
- Tested on dekstop Chrome

## Screenshots (Before and After on Mobile)
<img width="378" alt="image" src="https://github.com/user-attachments/assets/961c72d9-88ce-4380-b4f1-d9914746b30a" />
<img width="384" alt="image" src="https://github.com/user-attachments/assets/f9eebd57-0c61-4e0c-adcb-1f8a953c586b" />

cc: @MathyouMB 

